### PR TITLE
Reset batch size counter once capacity is reached

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -158,14 +158,12 @@ func (l *Loader) Load(key string) Thunk {
 	if l.cap > 0 {
 		l.countLock.Lock()
 		l.count++
+		l.countLock.Unlock()
 
 		// if we hit our limit, force the batch to start
 		if l.count == l.cap {
 			l.forceStartBatch <- true
-			l.count = 0
 		}
-
-		l.countLock.Unlock()
 	}
 
 	return thunk
@@ -281,5 +279,10 @@ func (l *Loader) sleeper() {
 	close(l.input)
 	l.input = make(chan *batchRequest, inputCap)
 	l.batching = false
+
+	l.countLock.Lock()
+	l.count = 0
+	l.countLock.Unlock()
+
 	l.inputLock.Unlock()
 }

--- a/dataloader.go
+++ b/dataloader.go
@@ -158,12 +158,14 @@ func (l *Loader) Load(key string) Thunk {
 	if l.cap > 0 {
 		l.countLock.Lock()
 		l.count++
-		l.countLock.Unlock()
 
 		// if we hit our limit, force the batch to start
 		if l.count == l.cap {
 			l.forceStartBatch <- true
+			l.count = 0
 		}
+
+		l.countLock.Unlock()
 	}
 
 	return thunk


### PR DESCRIPTION
Thanks for taking the initiative on this golang implementation of dataloader @nicksrandall!

I'm not exactly sure about this change, but it seems like we'd want to reset the `count` once we force the batch to start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/1)
<!-- Reviewable:end -->
