### PR TITLE
Handle incorrect BatchFunc behavior

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -324,6 +324,10 @@ func (l *Loader) batch() {
 
 	items := l.batchFn(keys)
 
+	if len(items) != len(reqs) {
+		// TODO: Some kind of error handling, like https://github.com/facebook/dataloader/blob/master/src/index.js#L271-L280
+	}
+
 	for i, req := range reqs {
 		req.channel <- items[i]
 		close(req.channel)


### PR DESCRIPTION
Currently there is no check that the number of items returned from a user-supplied batch function is the same as the number of requests.

This causes an uncaught panic when it occurs. The reference implementation throws an informative error in this case (https://github.com/facebook/dataloader/blob/master/src/index.js#L271-L280).

I wrote a failing test case to show the issue, but I'm not sure as to the best solution here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/5)
<!-- Reviewable:end -->
