### PR TITLE
Protect Against Panics

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -211,7 +211,14 @@ func (l *Loader) Load(key string) Thunk {
 		l.batchingLock.Lock()
 		l.batching = true
 		l.batchingLock.Unlock()
-		go l.batch()
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					c <- &Result{Error: fmt.Errorf("Panic received in batch function: %v", r)}
+				}
+			}()
+			l.batch()
+		}()
 	} else {
 		l.batchingLock.RUnlock()
 	}


### PR DESCRIPTION
Hi Nick,

Can I call you Nick? 

I recently noticed that panics are not caught in the call to `l.batch()`. The reason that this is important is because if a panic is allowed to propagate to the top of a goroutine, it will crash the process. Since dataloader spins up the goroutine, I feel like this project may be the most appropriate place to add protection against that. Please let me know if the problem and solution make sense. :)

Thanks for your time in creating and maintaining this project!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/14)
<!-- Reviewable:end -->
