### PR TITLE
Fix Race Condition in Thunks

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -179,7 +179,11 @@ func (l *Loader) Load(key string) Thunk {
 	}
 
 	thunk := func() (interface{}, error) {
-		if result.value == nil {
+		result.mu.RLock()
+		resultNotSet := result.value == nil
+		result.mu.RUnlock()
+
+		if resultNotSet {
 			result.mu.Lock()
 			if v, ok := <-c; ok {
 				result.value = v
@@ -277,7 +281,11 @@ func (l *Loader) LoadMany(keys []string) ThunkMany {
 	}
 
 	thunkMany := func() ([]interface{}, []error) {
-		if result.value == nil {
+		result.mu.RLock()
+		resultNotSet := result.value == nil
+		result.mu.RUnlock()
+
+		if resultNotSet {
 			result.mu.Lock()
 			if v, ok := <-c; ok {
 				result.value = v

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -26,7 +26,7 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
-	t.Run("test thunk passes race condition testing", func(t *testing.T) {
+	t.Run("test thunk does not contain race conditions", func(t *testing.T) {
 		t.Parallel()
 		identityLoader, _ := IDLoader(0)
 		future := identityLoader.Load("1")
@@ -60,7 +60,7 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
-	t.Run("test thunkmany passes race condition testing", func(t *testing.T) {
+	t.Run("test thunkmany does not contain race conditions", func(t *testing.T) {
 		t.Parallel()
 		identityLoader, _ := IDLoader(0)
 		future := identityLoader.LoadMany([]string{"1", "2", "3"})

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -26,6 +26,14 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
+	t.Run("test thunk passes race condition testing", func(t *testing.T) {
+		t.Parallel()
+		identityLoader, _ := IDLoader(0)
+		future := identityLoader.Load("1")
+		go future()
+		go future()
+	})
+
 	t.Run("test Load Method Panic Safety", func(t *testing.T) {
 		t.Parallel()
 		defer func() {
@@ -50,6 +58,14 @@ func TestLoader(t *testing.T) {
 		if len(err) != 3 {
 			t.Error("loadmany didn't return right number of errors")
 		}
+	})
+
+	t.Run("test thunkmany passes race condition testing", func(t *testing.T) {
+		t.Parallel()
+		identityLoader, _ := IDLoader(0)
+		future := identityLoader.LoadMany([]string{"1", "2", "3"})
+		go future()
+		go future()
 	})
 
 	t.Run("test Load Many Method Panic Safety", func(t *testing.T) {


### PR DESCRIPTION
A race condition occurs if one goroutine writes to `result.value` while another is attempting to read it. This patch forces the acquisition of the result's RWMutex read lock before it reads the value. 

Let me know if that makes sense!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/16)
<!-- Reviewable:end -->
