### PR TITLE
fix deadlock when panic in batch function for multiple keys

### DIFF
--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -50,6 +50,27 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
+	t.Run("test Load Method Panic Safety in multiple keys", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("Panic Loader's panic should have been handled'")
+			}
+		}()
+		panicLoader, _ := PanicLoader(0)
+		futures := []Thunk{}
+		for i := 0; i < 3;i++ {
+			futures = append(futures, panicLoader.Load(strconv.Itoa(i)))
+		}
+		for _, f := range futures {
+			_, err := f()
+			if err == nil || err.Error() != "Panic received in batch function: Programming error" {
+				t.Error("Panic was not propagated as an error.")
+			}
+		}
+	})
+
 	t.Run("test LoadMany method", func(t *testing.T) {
 		t.Parallel()
 		errorLoader, _ := ErrorLoader(0)


### PR DESCRIPTION
Hi Nick,
During the usage of the lib in our project, I found it hangs or deadlock when the batch function panic if it loads more than one key. Currently, if panic in batch function, it only send error result to the first request channel, and other request will wait forever.  I created this PR for the fix, can you take a look? Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/18)
<!-- Reviewable:end -->
