### PR TITLE
allow use of context in dataload in a backwards compatible way

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -21,8 +21,8 @@ import (
 // web request.
 type Interface interface {
 	Load(string) Thunk
-	LoadMany([]string) ThunkMany
 	LoadContext(context.Context, string) Thunk
+	LoadMany([]string) ThunkMany
 	LoadManyContext(context.Context, []string) ThunkMany
 	Clear(string) Interface
 	ClearAll() Interface
@@ -143,6 +143,7 @@ func WithWait(d time.Duration) Option {
 	}
 }
 
+// withSilentLogger is used by the tests to prevent logging
 func withSilentLogger() Option {
 	return func(l *Loader) {
 		l.silent = true
@@ -378,6 +379,7 @@ func (l *Loader) Prime(key string, value interface{}) Interface {
 	return l
 }
 
+// reset resets the current batcher
 func (l *Loader) reset() {
 	l.count = 0
 	l.curBatcher = nil
@@ -387,6 +389,7 @@ func (l *Loader) reset() {
 	}
 }
 
+// batcher is used to batch up request to BatchFunc
 type batcher struct {
 	input    chan *batchRequest
 	batchFn  BatchFuncContext

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -96,7 +96,7 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
-	t.Run("test LoadMany method", func(t *testing.T) {
+	t.Run("test LoadManyContext method", func(t *testing.T) {
 		t.Parallel()
 		errorLoader, _ := ErrorLoader(0)
 		ctx := context.Background()


### PR DESCRIPTION
@tonyghita this is my first pass at addressing your request. Would this solve your use case?

What I like about this implementation is that it introduces no breaking changes. 

### Usage
```golang
batchFn := func (ctx context.Context, keys []string) []*dataloader.Result {
  // use context for timeout/deadlines/ect...
}

loader := NewBatchedLoaderContext(batchFn)

loader.LoadContext(key)
```

The only potential problem I see here is that in order to use the context, you'll have to make sure that you always use "LoadContext", otherwise you'll get an empty context in your BatchFunc. Furthermore, the context that will be used in the BatchFunc will be the context of the first item in the batch (ie, the item that started the batch) which could be based on a race condition. So, I fear that users could have batches that *sometimes* fail because they forgot to use `LoadContext` in just one place. That could be a hard issue to track down?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/22)
<!-- Reviewable:end -->
