### PR TITLE
Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This project is a work in progress. Feedback is encouraged.
 ## Usage
 ```go
 // setup batch function
-batchFn := func(ctx context.Context, keys []string) []dataloader.Result {
-  var results []dataloader.Result
+batchFn := func(ctx context.Context, keys []string) []*dataloader.Result {
+  var results []*dataloader.Result
   // do some aync work to get data for specified keys
   // append to this list resolved values
   return results
@@ -27,7 +27,7 @@ loader := dataloader.NewBatchedLoader(batchFn)
 /**
  * Use loader
  *
- * A thunk is a function returned from a function that is a 
+ * A thunk is a function returned from a function that is a
  * closure over a value (in this case an interface value and error).
  * When called, it will block until the value is resolved.
  */


### PR DESCRIPTION
The return type of `BatchFunc` is defined as a slice of *pointers* to `Result`, i.e. `[]*Result`. However, in the usage example the pointers were missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/29)
<!-- Reviewable:end -->
