### PR TITLE
Change LoadMany() to return nil []error with no errors

### DIFF
--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -94,7 +94,6 @@ func TestLoader(t *testing.T) {
 		ctx := context.Background()
 		future := loader.LoadMany(ctx, []interface{}{"1", "2", "3"})
 		_, err := future()
-		log.Printf("errs: %#v", err)
 		if len(err) != 3 {
 			t.Errorf("LoadMany didn't return right number of errors (should match size of input)")
 		}
@@ -105,6 +104,16 @@ func TestLoader(t *testing.T) {
 
 		if err[1] != nil || err[2] != nil {
 			t.Error("Expected second and third errors to be nil")
+		}
+	})
+
+	t.Run("test LoadMany returns nil []error when no errors occurred", func(t *testing.T) {
+		t.Parallel()
+		loader, _ := IDLoader(0)
+		ctx := context.Background()
+		_, err := loader.LoadMany(ctx, []interface{}{"1", "2", "3"})()
+		if err != nil {
+			t.Errorf("Expected LoadMany() to return nil error slice when no errors occurred")
 		}
 	})
 
@@ -491,7 +500,7 @@ func OneErrorLoader(max int) (*Loader, *[][]interface{}) {
 	var mu sync.Mutex
 	var loadCalls [][]interface{}
 	identityLoader := NewBatchedLoader(func(_ context.Context, keys []interface{}) []*Result {
-		results := make([]*Result, max, max)
+		results := make([]*Result, max)
 		mu.Lock()
 		loadCalls = append(loadCalls, keys)
 		mu.Unlock()


### PR DESCRIPTION
This attempts to address the concerns from #31. This makes it easier for users of `LoadMany()` to handle the errors.

```go
var ldr *dataloader.Loader // assume this is instantiated somehow.

data, err := ldr.LoadMany(ctx, keys)
for i := range err { // does not enter loop when `err` == nil.
  d, e := data[i], errs[i]
  if e != nil {
    // do something with the result pair (d, e)
  }
} 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/32)
<!-- Reviewable:end -->
