### PR TITLE
RFC: Keyer interface in V5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is an implementation of [Facebook's DataLoader](https://github.com/facebook
 This project is a work in progress. Feedback is encouraged.
 
 ## Install
-`go get -u gopkg.in/nicksrandall/dataloader.v4`
+`go get -u gopkg.in/nicksrandall/dataloader.v5`
 
 ## Usage
 ```go
@@ -99,6 +99,32 @@ type Cache interface {
 +	Set(context.Context, interface{}, Thunk)
 -	Delete(context.Context, string) bool
 +	Delete(context.Context, interface{}) bool
+	Clear()
+}
+```
+
+## Upgrade from v4 to v5
+```diff
+// dataloader.Interface as now allows interace{} as key rather than string
+- loader.Load(context.Context, key interface{}) Thunk
++ loader.Load(ctx context.Context, key Key) Thunk
+- loader.LoadMany(context.Context, key []interface{}) ThunkMany
++ loader.LoadMany(ctx context.Context, keys Keys) ThunkMany
+- loader.Prime(context.Context, key interface{}, value interface{}) Interface
++ loader.Prime(ctx context.Context, key Key, value interface{}) Interface
+- loader.Clear(context.Context, key interface{}) Interface
++ loader.Clear(ctx context.Context, key Key) Interface
+```
+
+```diff
+// cache interface now allows interface{} as key instead of string
+type Cache interface {
+-	Get(context.Context, interface{}) (Thunk, bool)
++	Get(context.Context, Key) (Thunk, bool)
+-	Set(context.Context, interface{}, Thunk)
++	Set(context.Context, Key, Thunk)
+-	Delete(context.Context, interface{}) bool
++	Delete(context.Context, Key) bool
 	Clear()
 }
 ```

--- a/cache.go
+++ b/cache.go
@@ -4,9 +4,9 @@ import "context"
 
 // The Cache interface. If a custom cache is provided, it must implement this interface.
 type Cache interface {
-	Get(context.Context, interface{}) (Thunk, bool)
-	Set(context.Context, interface{}, Thunk)
-	Delete(context.Context, interface{}) bool
+	Get(context.Context, Key) (Thunk, bool)
+	Set(context.Context, Key, Thunk)
+	Delete(context.Context, Key) bool
 	Clear()
 }
 
@@ -16,13 +16,13 @@ type Cache interface {
 type NoCache struct{}
 
 // Get is a NOOP
-func (c *NoCache) Get(context.Context, interface{}) (Thunk, bool) { return nil, false }
+func (c *NoCache) Get(context.Context, Key) (Thunk, bool) { return nil, false }
 
 // Set is a NOOP
-func (c *NoCache) Set(context.Context, interface{}, Thunk) { return }
+func (c *NoCache) Set(context.Context, Key, Thunk) { return }
 
 // Delete is a NOOP
-func (c *NoCache) Delete(context.Context, interface{}) bool { return false }
+func (c *NoCache) Delete(context.Context, Key) bool { return false }
 
 // Clear is a NOOP
 func (c *NoCache) Clear() { return }

--- a/dataloader.go
+++ b/dataloader.go
@@ -20,18 +20,18 @@ import (
 // different access permissions and consider creating a new instance per
 // web request.
 type Interface interface {
-	Load(context.Context, interface{}) Thunk
-	LoadMany(context.Context, []interface{}) ThunkMany
-	Clear(context.Context, string) Interface
+	Load(context.Context, Key) Thunk
+	LoadMany(context.Context, Keys) ThunkMany
+	Clear(context.Context, Key) Interface
 	ClearAll() Interface
-	Prime(ctx context.Context, key interface{}, value interface{}) Interface
+	Prime(ctx context.Context, key Key, value interface{}) Interface
 }
 
 // BatchFunc is a function, which when given a slice of keys (string), returns an slice of `results`.
 // It's important that the length of the input keys matches the length of the output results.
 //
 // The keys passed to this function are guaranteed to be unique
-type BatchFunc func(context.Context, []interface{}) []*Result
+type BatchFunc func(context.Context, Keys) []*Result
 
 // Result is the data structure that a BatchFunc returns.
 // It contains the resolved data, and any errors that may have occurred while fetching the data.
@@ -100,7 +100,7 @@ type ThunkMany func() ([]interface{}, []error)
 
 // type used to on input channel
 type batchRequest struct {
-	key     interface{}
+	key     Key
 	channel chan *Result
 }
 
@@ -191,7 +191,7 @@ func NewBatchedLoader(batchFn BatchFunc, opts ...Option) *Loader {
 }
 
 // Load load/resolves the given key, returning a channel that will contain the value and error
-func (l *Loader) Load(originalContext context.Context, key interface{}) Thunk {
+func (l *Loader) Load(originalContext context.Context, key Key) Thunk {
 	ctx, finish := l.tracer.TraceLoad(originalContext, key)
 
 	c := make(chan *Result, 1)
@@ -267,7 +267,7 @@ func (l *Loader) Load(originalContext context.Context, key interface{}) Thunk {
 }
 
 // LoadMany loads mulitiple keys, returning a thunk (type: ThunkMany) that will resolve the keys passed in.
-func (l *Loader) LoadMany(originalContext context.Context, keys []interface{}) ThunkMany {
+func (l *Loader) LoadMany(originalContext context.Context, keys Keys) ThunkMany {
 	ctx, finish := l.tracer.TraceLoadMany(originalContext, keys)
 
 	var (
@@ -278,15 +278,17 @@ func (l *Loader) LoadMany(originalContext context.Context, keys []interface{}) T
 		wg     sync.WaitGroup
 	)
 
+	resolve := func(ctx context.Context, i int) {
+		defer wg.Done()
+		thunk := l.Load(ctx, keys[i])
+		result, err := thunk()
+		data[i] = result
+		errors[i] = err
+	}
+
 	wg.Add(length)
 	for i := range keys {
-		go func(ctx context.Context, i int) {
-			defer wg.Done()
-			thunk := l.Load(ctx, keys[i])
-			result, err := thunk()
-			data[i] = result
-			errors[i] = err
-		}(ctx, i)
+		go resolve(ctx, i)
 	}
 
 	go func() {
@@ -333,7 +335,7 @@ func (l *Loader) LoadMany(originalContext context.Context, keys []interface{}) T
 }
 
 // Clear clears the value at `key` from the cache, it it exsits. Returs self for method chaining
-func (l *Loader) Clear(ctx context.Context, key string) Interface {
+func (l *Loader) Clear(ctx context.Context, key Key) Interface {
 	l.cacheLock.Lock()
 	l.cache.Delete(ctx, key)
 	l.cacheLock.Unlock()
@@ -351,7 +353,7 @@ func (l *Loader) ClearAll() Interface {
 
 // Prime adds the provided key and value to the cache. If the key already exists, no change is made.
 // Returns self for method chaining
-func (l *Loader) Prime(ctx context.Context, key interface{}, value interface{}) Interface {
+func (l *Loader) Prime(ctx context.Context, key Key, value interface{}) Interface {
 	if _, ok := l.cache.Get(ctx, key); !ok {
 		thunk := func() (interface{}, error) {
 			return value, nil
@@ -399,10 +401,12 @@ func (b *batcher) end() {
 
 // execute the batch of all items in queue
 func (b *batcher) batch(originalContext context.Context) {
-	var keys []interface{}
-	var reqs []*batchRequest
-	var items []*Result
-	var panicErr interface{}
+	var (
+		keys     = make(Keys, 0)
+		reqs     = make([]*batchRequest, 0)
+		items    = make([]*Result, 0)
+		panicErr interface{}
+	)
 
 	for item := range b.input {
 		keys = append(keys, item.key)

--- a/example/lru-cache/golang-lru.go
+++ b/example/lru-cache/golang-lru.go
@@ -16,7 +16,7 @@ type Cache struct {
 }
 
 // Get gets an item from the cache
-func (c *Cache) Get(_ context.Context, key interface{}) (dataloader.Thunk, bool) {
+func (c *Cache) Get(_ context.Context, key dataloader.Key) (dataloader.Thunk, bool) {
 	v, ok := c.ARCCache.Get(key)
 	if ok {
 		return v.(dataloader.Thunk), ok
@@ -25,12 +25,12 @@ func (c *Cache) Get(_ context.Context, key interface{}) (dataloader.Thunk, bool)
 }
 
 // Set sets an item in the cache
-func (c *Cache) Set(_ context.Context, key interface{}, value dataloader.Thunk) {
+func (c *Cache) Set(_ context.Context, key dataloader.Key, value dataloader.Thunk) {
 	c.ARCCache.Add(key, value)
 }
 
 // Delete deletes an item in the cache
-func (c *Cache) Delete(_ context.Context, key interface{}) bool {
+func (c *Cache) Delete(_ context.Context, key dataloader.Key) bool {
 	if c.ARCCache.Contains(key) {
 		c.ARCCache.Remove(key)
 		return true
@@ -50,7 +50,7 @@ func main() {
 	loader := dataloader.NewBatchedLoader(batchFunc, dataloader.WithCache(cache))
 
 	// immediately call the future function from loader
-	result, err := loader.Load(context.TODO(), "some key")()
+	result, err := loader.Load(context.TODO(), dataloader.StringKey("some key"))()
 	if err != nil {
 		// handle error
 	}
@@ -58,11 +58,11 @@ func main() {
 	fmt.Printf("identity: %s\n", result)
 }
 
-func batchFunc(_ context.Context, keys []interface{}) []*dataloader.Result {
+func batchFunc(_ context.Context, keys dataloader.Keys) []*dataloader.Result {
 	var results []*dataloader.Result
 	// do some pretend work to resolve keys
 	for _, key := range keys {
-		results = append(results, &dataloader.Result{key, nil})
+		results = append(results, &dataloader.Result{key.String(), nil})
 	}
 	return results
 }

--- a/example/no-cache/no-cache.go
+++ b/example/no-cache/no-cache.go
@@ -12,7 +12,7 @@ func main() {
 	cache := &dataloader.NoCache{}
 	loader := dataloader.NewBatchedLoader(batchFunc, dataloader.WithCache(cache))
 
-	result, err := loader.Load(context.TODO(), "some key")()
+	result, err := loader.Load(context.TODO(), dataloader.StringKey("some key"))()
 	if err != nil {
 		// handle error
 	}
@@ -20,11 +20,11 @@ func main() {
 	fmt.Printf("identity: %s\n", result)
 }
 
-func batchFunc(_ context.Context, keys []interface{}) []*dataloader.Result {
+func batchFunc(_ context.Context, keys dataloader.Keys) []*dataloader.Result {
 	var results []*dataloader.Result
 	// do some pretend work to resolve keys
 	for _, key := range keys {
-		results = append(results, &dataloader.Result{key, nil})
+		results = append(results, &dataloader.Result{key.String(), nil})
 	}
 	return results
 }

--- a/example/ttl-cache/go-cache.go
+++ b/example/ttl-cache/go-cache.go
@@ -17,8 +17,8 @@ type Cache struct {
 }
 
 // Get gets a value from the cache
-func (c *Cache) Get(_ context.Context, key interface{}) (dataloader.Thunk, bool) {
-	v, ok := c.c.Get(key.(string))
+func (c *Cache) Get(_ context.Context, key dataloader.Key) (dataloader.Thunk, bool) {
+	v, ok := c.c.Get(key.String())
 	if ok {
 		return v.(dataloader.Thunk), ok
 	}
@@ -26,14 +26,14 @@ func (c *Cache) Get(_ context.Context, key interface{}) (dataloader.Thunk, bool)
 }
 
 // Set sets a value in the cache
-func (c *Cache) Set(_ context.Context, key interface{}, value dataloader.Thunk) {
-	c.c.Set(key.(string), value, 0)
+func (c *Cache) Set(_ context.Context, key dataloader.Key, value dataloader.Thunk) {
+	c.c.Set(key.String(), value, 0)
 }
 
 // Delete deletes and item in the cache
-func (c *Cache) Delete(_ context.Context, key interface{}) bool {
-	if _, found := c.c.Get(key.(string)); found {
-		c.c.Delete(key.(string))
+func (c *Cache) Delete(_ context.Context, key dataloader.Key) bool {
+	if _, found := c.c.Get(key.String()); found {
+		c.c.Delete(key.String())
 		return true
 	}
 	return false
@@ -51,7 +51,7 @@ func main() {
 	loader := dataloader.NewBatchedLoader(batchFunc, dataloader.WithCache(cache))
 
 	// immediately call the future function from loader
-	result, err := loader.Load(context.TODO(), "some key")()
+	result, err := loader.Load(context.TODO(), dataloader.StringKey("some key"))()
 	if err != nil {
 		// handle error
 	}
@@ -59,11 +59,11 @@ func main() {
 	fmt.Printf("identity: %s\n", result)
 }
 
-func batchFunc(_ context.Context, keys []interface{}) []*dataloader.Result {
+func batchFunc(_ context.Context, keys dataloader.Keys) []*dataloader.Result {
 	var results []*dataloader.Result
 	// do some pretend work to resolve keys
 	for _, key := range keys {
-		results = append(results, &dataloader.Result{key, nil})
+		results = append(results, &dataloader.Result{key.String(), nil})
 	}
 	return results
 }

--- a/inMemoryCache.go
+++ b/inMemoryCache.go
@@ -13,7 +13,7 @@ import (
 // for the life of an http request) but it not well suited
 // for long lived cached items.
 type InMemoryCache struct {
-	items map[interface{}]Thunk
+	items map[string]Thunk
 	mu    sync.RWMutex
 }
 
@@ -26,19 +26,19 @@ func NewCache() *InMemoryCache {
 }
 
 // Set sets the `value` at `key` in the cache
-func (c *InMemoryCache) Set(_ context.Context, key interface{}, value Thunk) {
+func (c *InMemoryCache) Set(_ context.Context, key Key, value Thunk) {
 	c.mu.Lock()
-	c.items[key] = value
+	c.items[key.Key()] = value
 	c.mu.Unlock()
 }
 
 // Get gets the value at `key` if it exsits, returns value (or nil) and bool
 // indicating of value was found
-func (c *InMemoryCache) Get(_ context.Context, key interface{}) (Thunk, bool) {
+func (c *InMemoryCache) Get(_ context.Context, key Key) (Thunk, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	item, found := c.items[key]
+	item, found := c.items[key.Key()]
 	if !found {
 		return nil, false
 	}
@@ -51,7 +51,7 @@ func (c *InMemoryCache) Delete(ctx context.Context, key interface{}) bool {
 	if _, found := c.Get(ctx, key); found {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		delete(c.items, key)
+		delete(c.items, key.Key())
 		return true
 	}
 	return false
@@ -60,6 +60,6 @@ func (c *InMemoryCache) Delete(ctx context.Context, key interface{}) bool {
 // Clear clears the entire cache
 func (c *InMemoryCache) Clear() {
 	c.mu.Lock()
-	c.items = map[interface{}]Thunk{}
+	c.items = map[string]Thunk{}
 	c.mu.Unlock()
 }

--- a/inMemoryCache_go19.go
+++ b/inMemoryCache_go19.go
@@ -24,14 +24,14 @@ func NewCache() *InMemoryCache {
 }
 
 // Set sets the `value` at `key` in the cache
-func (c *InMemoryCache) Set(_ context.Context, key interface{}, value Thunk) {
-	c.items.Store(key, value)
+func (c *InMemoryCache) Set(_ context.Context, key Key, value Thunk) {
+	c.items.Store(key.String(), value)
 }
 
 // Get gets the value at `key` if it exsits, returns value (or nil) and bool
 // indicating of value was found
-func (c *InMemoryCache) Get(_ context.Context, key interface{}) (Thunk, bool) {
-	item, found := c.items.Load(key)
+func (c *InMemoryCache) Get(_ context.Context, key Key) (Thunk, bool) {
+	item, found := c.items.Load(key.String())
 	if !found {
 		return nil, false
 	}
@@ -40,9 +40,9 @@ func (c *InMemoryCache) Get(_ context.Context, key interface{}) (Thunk, bool) {
 }
 
 // Delete deletes item at `key` from cache
-func (c *InMemoryCache) Delete(_ context.Context, key interface{}) bool {
-	if _, found := c.items.Load(key); found {
-		c.items.Delete(key)
+func (c *InMemoryCache) Delete(_ context.Context, key Key) bool {
+	if _, found := c.items.Load(key.String()); found {
+		c.items.Delete(key.String())
 		return true
 	}
 	return false

--- a/key.go
+++ b/key.go
@@ -1,0 +1,39 @@
+package dataloader
+
+// Key is the interface that all keys need to implement
+type Key interface {
+	// String returns a guaranteed unique string that can be used to identify an object
+	String() string
+	// Raw returns the raw, underlaying value of the key
+	Raw() interface{}
+}
+
+// Keys wraps a slice of Key types to provide some convenience methods.
+type Keys []Key
+
+// Keys returns the list of strings. One for each "Key" in the list
+func (l Keys) Keys() []string {
+	list := make([]string, len(l))
+	for i := range l {
+		list[i] = l[i].String()
+	}
+	return list
+}
+
+// StringKey implements the Key interface for a string
+type StringKey string
+
+// String is an identity method. Used to implement String interface
+func (k StringKey) String() string { return string(k) }
+
+// String is an identity method. Used to implement Key Raw
+func (k StringKey) Raw() interface{} { return k }
+
+// NewKeysFromStrings converts a `[]strings` to a `Keys` ([]Key)
+func NewKeysFromStrings(strings []string) Keys {
+	list := make(Keys, len(strings))
+	for i := range strings {
+		list[i] = StringKey(strings[i])
+	}
+	return list
+}

--- a/trace.go
+++ b/trace.go
@@ -13,21 +13,21 @@ type TraceBatchFinishFunc func([]*Result)
 // Tracer is an interface that may be used to implement tracing.
 type Tracer interface {
 	// TraceLoad will trace the calls to Load
-	TraceLoad(ctx context.Context, key interface{}) (context.Context, TraceLoadFinishFunc)
+	TraceLoad(ctx context.Context, key Key) (context.Context, TraceLoadFinishFunc)
 	// TraceLoadMany will trace the calls to LoadMany
-	TraceLoadMany(ctx context.Context, keys []interface{}) (context.Context, TraceLoadManyFinishFunc)
+	TraceLoadMany(ctx context.Context, keys Keys) (context.Context, TraceLoadManyFinishFunc)
 	// TraceBatch will trace data loader batches
-	TraceBatch(ctx context.Context, keys []interface{}) (context.Context, TraceBatchFinishFunc)
+	TraceBatch(ctx context.Context, keys Keys) (context.Context, TraceBatchFinishFunc)
 }
 
 // OpenTracing Tracer implements a tracer that can be used with the Open Tracing standard.
 type OpenTracingTracer struct{}
 
 // TraceLoad will trace a call to dataloader.LoadMany with Open Tracing
-func (OpenTracingTracer) TraceLoad(ctx context.Context, key interface{}) (context.Context, TraceLoadFinishFunc) {
+func (OpenTracingTracer) TraceLoad(ctx context.Context, key Key) (context.Context, TraceLoadFinishFunc) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: load")
 
-	span.SetTag("dataloader.key", key)
+	span.SetTag("dataloader.key", key.String())
 
 	return spanCtx, func(thunk Thunk) {
 		// TODO: is there anything we should do with the results?
@@ -36,10 +36,10 @@ func (OpenTracingTracer) TraceLoad(ctx context.Context, key interface{}) (contex
 }
 
 // TraceLoadMany will trace a call to dataloader.LoadMany with Open Tracing
-func (OpenTracingTracer) TraceLoadMany(ctx context.Context, keys []interface{}) (context.Context, TraceLoadManyFinishFunc) {
+func (OpenTracingTracer) TraceLoadMany(ctx context.Context, keys Keys) (context.Context, TraceLoadManyFinishFunc) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: loadmany")
 
-	span.SetTag("dataloader.keys", keys)
+	span.SetTag("dataloader.keys", keys.Keys())
 
 	return spanCtx, func(thunk ThunkMany) {
 		// TODO: is there anything we should do with the results?
@@ -48,10 +48,10 @@ func (OpenTracingTracer) TraceLoadMany(ctx context.Context, keys []interface{}) 
 }
 
 // TraceBatch will trace a call to dataloader.LoadMany with Open Tracing
-func (OpenTracingTracer) TraceBatch(ctx context.Context, keys []interface{}) (context.Context, TraceBatchFinishFunc) {
+func (OpenTracingTracer) TraceBatch(ctx context.Context, keys Keys) (context.Context, TraceBatchFinishFunc) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: batch")
 
-	span.SetTag("dataloader.keys", keys)
+	span.SetTag("dataloader.keys", keys.Keys())
 
 	return spanCtx, func(results []*Result) {
 		// TODO: is there anything we should do with the results?
@@ -63,16 +63,16 @@ func (OpenTracingTracer) TraceBatch(ctx context.Context, keys []interface{}) (co
 type NoopTracer struct{}
 
 // TraceLoad is a noop function
-func (NoopTracer) TraceLoad(ctx context.Context, key interface{}) (context.Context, TraceLoadFinishFunc) {
+func (NoopTracer) TraceLoad(ctx context.Context, key Key) (context.Context, TraceLoadFinishFunc) {
 	return ctx, func(Thunk) {}
 }
 
 // TraceLoadMany is a noop function
-func (NoopTracer) TraceLoadMany(ctx context.Context, keys []interface{}) (context.Context, TraceLoadManyFinishFunc) {
+func (NoopTracer) TraceLoadMany(ctx context.Context, keys Keys) (context.Context, TraceLoadManyFinishFunc) {
 	return ctx, func(ThunkMany) {}
 }
 
 // TraceBatch is a noop function
-func (NoopTracer) TraceBatch(ctx context.Context, keys []interface{}) (context.Context, TraceBatchFinishFunc) {
+func (NoopTracer) TraceBatch(ctx context.Context, keys Keys) (context.Context, TraceBatchFinishFunc) {
 	return ctx, func(result []*Result) {}
 }


### PR DESCRIPTION
I believe that this more closely follows the dataloader spec and it also solves a few of the concerns I have with v4 implementation. This implementation allows users to pass anything into the loader that can be coerced into a string (i.e. implements the `Keyer` interface). 

Feedback is encouraged.

cc: @tonyghita @mastertinner

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicksrandall/dataloader/36)
<!-- Reviewable:end -->
